### PR TITLE
for serializing and sending, types are unnecessary

### DIFF
--- a/Ve.Messaging.Azure.ServiceBus/Thrift/Interfaces/IThriftConsumer.cs
+++ b/Ve.Messaging.Azure.ServiceBus/Thrift/Interfaces/IThriftConsumer.cs
@@ -1,10 +1,9 @@
 ﻿using System.Collections.Generic;
-using Ve.Messaging.Thrift;
 
 namespace Ve.Messaging.Azure.ServiceBus.Thrift.Interfaces
 {
     public interface IThriftConsumer
     {
-        IEnumerable<ThriftMessage<T>> RetrieveMessages<T>(int messageAmount, int timeout) where T : new();
+        IEnumerable<T> RetrieveMessages<T>(int messageAmount, int timeout) where T : new();
     }
 }

--- a/Ve.Messaging.Azure.ServiceBus/Thrift/Interfaces/IThriftPublisher.cs
+++ b/Ve.Messaging.Azure.ServiceBus/Thrift/Interfaces/IThriftPublisher.cs
@@ -1,12 +1,12 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using Ve.Messaging.Thrift;
+using Ve.Messaging.Model;
 
 namespace Ve.Messaging.Azure.ServiceBus.Thrift.Interfaces
 {
     public interface IThriftPublisher
     {
-        Task SendAsync<T>(ThriftMessage<T> thriftMessage) where T : new();
-        Task SendBatchAsync<T>(IEnumerable<ThriftMessage<T>> messages) where T : new();
+        Task SendAsync(Message thriftMessage);
+        Task SendBatchAsync(IEnumerable<Message> messages);
     }
 }

--- a/Ve.Messaging.Azure.ServiceBus/Thrift/ThriftConsumer.cs
+++ b/Ve.Messaging.Azure.ServiceBus/Thrift/ThriftConsumer.cs
@@ -14,11 +14,11 @@ namespace Ve.Messaging.Azure.ServiceBus.Thrift
         {
             _consumer = consumer;
         }
-        public IEnumerable<ThriftMessage<T>> RetrieveMessages<T>(int messageAmount, int timeout) where T : new()
+
+        public IEnumerable<T> RetrieveMessages<T>(int messageAmount, int timeout) where T : new()
         {
             return _consumer.RetrieveMessages(messageAmount, timeout).Select(
-                m => new ThriftMessage<T>(m));
+                m => ThriftSerializer.Deserialize<T>(m.BodyStream));
         }
-
     }
 }

--- a/Ve.Messaging.Azure.ServiceBus/Thrift/ThriftPublisher.cs
+++ b/Ve.Messaging.Azure.ServiceBus/Thrift/ThriftPublisher.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Ve.Messaging.Azure.ServiceBus.Thrift.Interfaces;
+using Ve.Messaging.Model;
 using Ve.Messaging.Publisher;
-using Ve.Messaging.Thrift;
 
 namespace Ve.Messaging.Azure.ServiceBus.Thrift
 {
@@ -15,12 +15,12 @@ namespace Ve.Messaging.Azure.ServiceBus.Thrift
             _publisher = publisher;
         }
 
-        public Task SendAsync<T>(ThriftMessage<T> thriftMessage) where T : new()
+        public Task SendAsync(Message message)
         {
-            return _publisher.SendAsync(thriftMessage);
+            return _publisher.SendAsync(message);
         }
 
-        public async Task SendBatchAsync<T>(IEnumerable<ThriftMessage<T>> messages) where T : new()
+        public async Task SendBatchAsync(IEnumerable<Message> messages)
         {
             foreach (var message in messages)
             {

--- a/Ve.Messaging.SampleApp/Program.cs
+++ b/Ve.Messaging.SampleApp/Program.cs
@@ -11,6 +11,7 @@ using Ve.Messaging.Azure.ServiceBus.Thrift;
 using Ve.Messaging.Azure.ServiceBus.Thrift.Interfaces;
 using Ve.Messaging.Samples;
 using Ve.Messaging.Thrift;
+using Ve.Metrics.StatsDClient.Abstract;
 
 namespace Ve.Messaging.SampleApp
 {
@@ -39,7 +40,7 @@ namespace Ve.Messaging.SampleApp
 
                     foreach (var message in messages)
                     {
-                        Console.WriteLine($"House: {message.Content.Name} of {message.Content.Owner}");
+                        Console.WriteLine($"House: {message.Name} of {message.Owner}");
                     }
                 }
             });
@@ -74,7 +75,7 @@ namespace Ve.Messaging.SampleApp
             }
         }
 
-        private static PublisherFactory GetPublisher(VeStatsDClient client)
+        private static PublisherFactory GetPublisher(IVeStatsDClient client)
         {
             var publisherFactory = new PublisherFactory(
                 client,

--- a/Ve.Messaging.Tests/ThriftMessageShould.cs
+++ b/Ve.Messaging.Tests/ThriftMessageShould.cs
@@ -41,7 +41,7 @@ namespace Ve.Messaging.Tests
         public void Set_Message()
         {
             var houseDto = GetHouseDto();
-            var bodyStream = ThriftSerializer.Serialize<HouseDto>(houseDto);
+            var bodyStream = ThriftSerializer.Serialize(houseDto);
             var message = new Message(bodyStream);
             
             var thriftMessage = new ThriftMessage<HouseDto>(message);
@@ -59,7 +59,7 @@ namespace Ve.Messaging.Tests
             };
             string sessionId = Guid.NewGuid().ToString();
             string label = Guid.NewGuid().ToString();
-            var bodyStream = ThriftSerializer.Serialize<HouseDto>(houseDto);
+            var bodyStream = ThriftSerializer.Serialize(houseDto);
             var message = new Message(bodyStream, sessionId, label, properties);
 
             var thriftMessage = new ThriftMessage<HouseDto>(message);

--- a/Ve.Messaging.Thrift/ThriftMessage.cs
+++ b/Ve.Messaging.Thrift/ThriftMessage.cs
@@ -9,8 +9,8 @@ namespace Ve.Messaging.Thrift
         public ThriftMessage(T content,
                              string sessionId = "",
                              string label = "",
-                             Dictionary<string, object> properties = null)
-                             : base(ThriftSerializer.Serialize<T>(content), sessionId, label, properties)
+                             IDictionary<string, object> properties = null)
+                             : base(ThriftSerializer.Serialize(content), sessionId, label, properties)
         {
             Content = content;
         }
@@ -18,7 +18,7 @@ namespace Ve.Messaging.Thrift
         public ThriftMessage(Stream bodyContent,
                              string sessionId = "",
                              string label = "",
-                             Dictionary<string, object> properties = null)
+                             IDictionary<string, object> properties = null)
                              : base(bodyContent, sessionId, label, properties)
         {
             Content = ThriftSerializer.Deserialize<T>(bodyContent);

--- a/Ve.Messaging.Thrift/ThriftSerializer.cs
+++ b/Ve.Messaging.Thrift/ThriftSerializer.cs
@@ -6,7 +6,7 @@ namespace Ve.Messaging.Thrift
 {
     public static class ThriftSerializer 
     {
-        public static Stream Serialize<T>(object value)
+        public static Stream Serialize(object value)
         {
             using (TMemoryBuffer trans = new TMemoryBuffer())
             {
@@ -18,7 +18,7 @@ namespace Ve.Messaging.Thrift
                 return memoryStream;
             }
         }
-        public static byte[] SerializeGetBytes<T>(object value)
+        public static byte[] SerializeGetBytes(object value)
         {
             using (TMemoryBuffer trans = new TMemoryBuffer())
             {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.2.{build}
+version: 0.3.{build}
 configuration: Release
 skip_tags: true
 environment:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,6 @@
+branches:
+  only:
+    - master
 version: 0.3.{build}
 configuration: Release
 skip_tags: true
@@ -31,7 +34,7 @@ deploy:
     secure: 9VQU1tM1eJOhWwZvwKm00ndEGr+GPyeYm49nWZPWDDmNvKYe4z+mmeGtHe+R9GDh 
   skip_symbols: false
   artifact: /.*\.nupkg/
-on_success:
+after_deploy:
     - git config --global credential.helper store
     - ps: Add-Content "$env:USERPROFILE\.git-credentials" "https://$($env:git_token):x-oauth-basic@github.com`n"
     - git tag -a release/%APPVEYOR_BUILD_VERSION% -m "Added tag"


### PR DESCRIPTION
There is actually no need to specify the concrete type when sending a message. The sending logic only deals with the base `Message` type anyway, so adding type arguments just makes the sending code more awkward (especially when sending different types of messages).
