### PR TITLE
Simplify thrift publisher consumer

### DIFF
--- a/Ve.Messaging.Azure.ServiceBus/Consumer/ConsumerConfiguration.cs
+++ b/Ve.Messaging.Azure.ServiceBus/Consumer/ConsumerConfiguration.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Ve.Messaging.Azure.ServiceBus.Infrastructure
+namespace Ve.Messaging.Azure.ServiceBus.Consumer
 {
     public class ConsumerConfiguration
     {

--- a/Ve.Messaging.Azure.ServiceBus/Consumer/ConsumerFactory.cs
+++ b/Ve.Messaging.Azure.ServiceBus/Consumer/ConsumerFactory.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Microsoft.ServiceBus;
 using Microsoft.ServiceBus.Messaging;
-using Ve.Messaging.Azure.ServiceBus.Infrastructure;
 using Ve.Messaging.Consumer;
 
 namespace Ve.Messaging.Azure.ServiceBus.Consumer

--- a/Ve.Messaging.Azure.ServiceBus/Thrift/Interfaces/IThriftConsumer.cs
+++ b/Ve.Messaging.Azure.ServiceBus/Thrift/Interfaces/IThriftConsumer.cs
@@ -1,7 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Ve.Messaging.Azure.ServiceBus.Thrift.Interfaces
 {
+    [Obsolete("Prefer extension method")]
     public interface IThriftConsumer
     {
         IEnumerable<T> RetrieveMessages<T>(int messageAmount, int timeout) where T : new();

--- a/Ve.Messaging.Azure.ServiceBus/Thrift/Interfaces/ThriftMessageConsumerExts.cs
+++ b/Ve.Messaging.Azure.ServiceBus/Thrift/Interfaces/ThriftMessageConsumerExts.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Ve.Messaging.Consumer;
+using Ve.Messaging.Thrift;
+
+namespace Ve.Messaging.Azure.ServiceBus.Thrift.Interfaces
+{
+    public static class ThriftMessageConsumerExts
+    {
+        public static IEnumerable<T> RetrieveMessages<T>(this IMessageConsumer consumer, int messageAmount, int timeout) where T : new()
+        {
+            return consumer.RetrieveMessages(messageAmount, timeout).Select(m => ThriftSerializer.Deserialize<T>(m.BodyStream));
+        }
+    }
+}

--- a/Ve.Messaging.Azure.ServiceBus/Thrift/ThriftConsumer.cs
+++ b/Ve.Messaging.Azure.ServiceBus/Thrift/ThriftConsumer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Ve.Messaging.Azure.ServiceBus.Thrift.Interfaces;
 using Ve.Messaging.Consumer;
@@ -6,7 +7,8 @@ using Ve.Messaging.Thrift;
 
 namespace Ve.Messaging.Azure.ServiceBus.Thrift
 {
-    public class ThriftConsumer : IThriftConsumer
+    [Obsolete("Prefer extension method: RetrieveThriftMessages")]
+    public class ThriftConsumer : IThriftConsumer 
     {
         private readonly IMessageConsumer _consumer;
 
@@ -21,4 +23,6 @@ namespace Ve.Messaging.Azure.ServiceBus.Thrift
                 m => ThriftSerializer.Deserialize<T>(m.BodyStream));
         }
     }
+
+
 }

--- a/Ve.Messaging.Azure.ServiceBus/Thrift/ThriftPublisher.cs
+++ b/Ve.Messaging.Azure.ServiceBus/Thrift/ThriftPublisher.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Ve.Messaging.Azure.ServiceBus.Thrift.Interfaces;
@@ -6,7 +7,8 @@ using Ve.Messaging.Publisher;
 
 namespace Ve.Messaging.Azure.ServiceBus.Thrift
 {
-    public class ThriftPublisher : IThriftPublisher
+    [Obsolete("Redundant interface, prefer IMessagePublisher")]
+    public class ThriftPublisher : IThriftPublisher // TODO: why does this exist? Does it even do anything different to, IMessagePublisher? Seems to prevent the EventHub behaviour
     {
         private readonly IMessagePublisher _publisher;
 

--- a/Ve.Messaging.Azure.ServiceBus/Ve.Messaging.Azure.ServiceBus.csproj
+++ b/Ve.Messaging.Azure.ServiceBus/Ve.Messaging.Azure.ServiceBus.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Publisher\ServiceBusPublisherStrategy.cs" />
     <Compile Include="Thrift\Interfaces\IThriftPublisher.cs" />
     <Compile Include="Thrift\Interfaces\IThriftConsumer.cs" />
+    <Compile Include="Thrift\Interfaces\ThriftMessageConsumerExts.cs" />
     <Compile Include="Thrift\ThriftConsumer.cs" />
     <Compile Include="Thrift\ThriftPublisher.cs" />
     <Compile Include="Publisher\TopicClientCreator.cs" />

--- a/Ve.Messaging.SampleApp/Program.cs
+++ b/Ve.Messaging.SampleApp/Program.cs
@@ -5,10 +5,10 @@ using System.Runtime.Serialization.Formatters.Binary;
 using System.Threading.Tasks;
 using Ve.Metrics.StatsDClient;
 using Ve.Messaging.Azure.ServiceBus.Consumer;
-using Ve.Messaging.Azure.ServiceBus.Infrastructure;
 using Ve.Messaging.Azure.ServiceBus.Publisher;
-using Ve.Messaging.Azure.ServiceBus.Thrift;
 using Ve.Messaging.Azure.ServiceBus.Thrift.Interfaces;
+using Ve.Messaging.Consumer;
+using Ve.Messaging.Publisher;
 using Ve.Messaging.Samples;
 using Ve.Messaging.Thrift;
 using Ve.Metrics.StatsDClient.Abstract;
@@ -18,8 +18,7 @@ namespace Ve.Messaging.SampleApp
     public class Program
     {
         static string YOUR_PRIMARY_CONNECTION_STRING = "ServiceBus.ConnectionString.Primary";
-        static string YOUR_FAILOVER_CONNECTION_STRING = "ServiceBus.ConnectionString.Failover";
-        
+
         static void Main(string[] args)
         {
             var statsdConfig = InstantiateStatsdConfig();
@@ -47,16 +46,14 @@ namespace Ve.Messaging.SampleApp
             Console.ReadLine();
         }
 
-        private static ThriftConsumer GetConsumer()
+        private static IMessageConsumer GetConsumer()
         {
             string primaryConnectionString = ConfigurationManager.AppSettings[YOUR_PRIMARY_CONNECTION_STRING];
             var factory = new ConsumerFactory();
-            var consumer = factory.GetConsumer(new ConsumerConfiguration(primaryConnectionString, "testtopic3", "testsubsccription", TimeSpan.MaxValue));
-            return new ThriftConsumer(consumer);
-
+            return factory.GetConsumer(new ConsumerConfiguration(primaryConnectionString, "testtopic3", "testsubsccription", TimeSpan.MaxValue));
         }
 
-        private static void SendMultipleMessages(IThriftPublisher sender)
+        private static void SendMultipleMessages(IMessagePublisher sender)
         {
             for (int i = 0; i < 10; i++)
             {
@@ -84,7 +81,7 @@ namespace Ve.Messaging.SampleApp
             return publisherFactory;
         }
 
-        private static ThriftPublisher GetSender(PublisherFactory publisherFactory)
+        private static IMessagePublisher GetSender(PublisherFactory publisherFactory)
         {
             string primaryConnectionString = ConfigurationManager.AppSettings[YOUR_PRIMARY_CONNECTION_STRING];
             var sender = publisherFactory.CreatePublisher(new ServiceBusPublisherConfiguration()
@@ -96,8 +93,7 @@ namespace Ve.Messaging.SampleApp
                 },
                 ServiceBusPublisherStrategy = ServiceBusPublisherStrategy.Simple
             });
-            var publisher = new ThriftPublisher(sender);
-            return publisher;
+            return sender;
         }
 
         private static StatsdConfig InstantiateStatsdConfig()


### PR DESCRIPTION
Maybe this is interesting to you guys.

I think we don't really need the `IThriftConsumer` and `IThriftPublisher` interfaces.
I've updated the sample, and you can see it reduces the line count and number of objects by a couple.

At the moment, I have kept them, but marked as Obsolete for backwards compatibility reasons. After a while I'd recommend deleting them.

On a side note, it looks like it did something funny with the CSproj. It should only be a 1 line diff of adding the extension method class.
