### PR TITLE
expose peek on IMessageConsumer

### DIFF
--- a/Ve.Messaging.Azure.ServiceBus/Consumer/MessageConsumer.cs
+++ b/Ve.Messaging.Azure.ServiceBus/Consumer/MessageConsumer.cs
@@ -39,5 +39,16 @@ namespace Ve.Messaging.Azure.ServiceBus.Consumer
         {
             _client.Close();
         }
+
+        public Message Peek()
+        {
+            var message = _client.Peek();
+
+            return new Message(
+                message.GetBody<Stream>(),
+                message.SessionId,
+                message.Label,
+                message.Properties);
+        }
     }
 }

--- a/Ve.Messaging/Consumer/IMessageConsumer.cs
+++ b/Ve.Messaging/Consumer/IMessageConsumer.cs
@@ -7,5 +7,6 @@ namespace Ve.Messaging.Consumer
     public interface IMessageConsumer : IDisposable
     {
         IEnumerable<Message> RetrieveMessages(int messageAmount, int timeout);
+        Message Peek();
     }
 }


### PR DESCRIPTION
Expose the `.Peek()` method on the MessageConsumer to provide an easy way to interrogate the client (i.e. to validate that it can receive messages correctly)
