### PR TITLE
set label/session properties for compatibility with amqp consumers

### DIFF
--- a/Ve.Messaging.Azure.ServiceBus.Test/BrokeredMessageBuilderShould.cs
+++ b/Ve.Messaging.Azure.ServiceBus.Test/BrokeredMessageBuilderShould.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using NUnit.Framework;
+using Shouldly;
+using Ve.Messaging.Azure.ServiceBus.Infrastructure;
+using Ve.Messaging.Model;
+
+namespace Ve.Messaging.Azure.ServiceBus.Test
+{
+    [TestFixture]
+    public class BrokeredMessageBuilderShould
+    {
+        private string _sessionId;
+        private string _label;
+
+        [SetUp]
+        public void Setup()
+        {
+            _sessionId = Guid.NewGuid().ToString();
+            _label = Guid.NewGuid().ToString();
+        }
+        
+        [Test]
+        public void It_should_set_the_label()
+        {
+            var result = BrokeredMessageBuilder.SerializeToBrokeredMessage(GetMessage());
+
+            result.Label.ShouldBe(_label);
+        }
+        
+        [Test]
+        public void It_should_set_the_sessionId()
+        {
+            var result = BrokeredMessageBuilder.SerializeToBrokeredMessage(GetMessage());
+
+            result.SessionId.ShouldBe(_sessionId);
+        }
+
+        [Test]
+        public void It_should_set_the_label_property()
+        {
+            var result = BrokeredMessageBuilder.SerializeToBrokeredMessage(GetMessage());
+
+            result.Properties["Label"].ShouldBe(_label);
+        }
+
+        [Test]
+        public void It_should_set_the_sessionId_property()
+        {
+            var result = BrokeredMessageBuilder.SerializeToBrokeredMessage(GetMessage());
+
+            result.Properties["SessionId"].ShouldBe(_sessionId);
+        }
+        
+        [Test]
+        public void It_should_set_the_custom_properties()
+        {
+            var result = BrokeredMessageBuilder.SerializeToBrokeredMessage(new Message(new MemoryStream(), _sessionId, _label, new Dictionary<string, object>()
+            {
+                { "foo", "bar" }
+            }));
+
+            result.Properties["foo"].ShouldBe("bar");
+        }
+
+        private Message GetMessage()
+        {
+            return new Message(new MemoryStream(), _sessionId, _label);
+        }
+    }
+}

--- a/Ve.Messaging.Azure.ServiceBus.Test/Ve.Messaging.Azure.ServiceBus.Test.csproj
+++ b/Ve.Messaging.Azure.ServiceBus.Test/Ve.Messaging.Azure.ServiceBus.Test.csproj
@@ -46,6 +46,10 @@
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Shouldly, Version=2.8.0.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">
+      <HintPath>..\packages\Shouldly.2.8.0\lib\net40\Shouldly.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />
@@ -62,6 +66,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BrokeredMessageBuilderShould.cs" />
     <Compile Include="MessagePublisherShould.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ThriftPublisherShould.cs" />

--- a/Ve.Messaging.Azure.ServiceBus.Test/packages.config
+++ b/Ve.Messaging.Azure.ServiceBus.Test/packages.config
@@ -3,6 +3,7 @@
   <package id="Castle.Core" version="3.3.3" targetFramework="net452" />
   <package id="Moq" version="4.6.38-alpha" targetFramework="net452" />
   <package id="NUnit" version="2.6.4" targetFramework="net452" />
+  <package id="Shouldly" version="2.8.0" targetFramework="net452" />
   <package id="Thrift" version="0.9.1.3" targetFramework="net452" />
   <package id="WindowsAzure.ServiceBus" version="3.1.7" targetFramework="net452" />
 </packages>

--- a/Ve.Messaging.Azure.ServiceBus/Infrastructure/BrokeredMessageBuilder.cs
+++ b/Ve.Messaging.Azure.ServiceBus/Infrastructure/BrokeredMessageBuilder.cs
@@ -19,6 +19,10 @@ namespace Ve.Messaging.Azure.ServiceBus.Infrastructure
 
         private static void AddProperties(Message message, BrokeredMessage brokeredMessage)
         {
+            // for compatibility with AMQP consumers
+            brokeredMessage.Properties.Add("Label", message.Label);
+            brokeredMessage.Properties.Add("SessionId", message.SessionId);
+
             if (message.Properties != null && message.Properties.Count > 0)
             {
                 foreach (var item in message.Properties)


### PR DESCRIPTION
The AMQP implementation for servicebus doesn't expose the `SessionId` or `Label` fields (because they are not part of the AQMP spec, so to work around this we explicitly set `Label` and `SessionId` in the message properties so that any AMQP consumers can assume these exist.

Consumers that use the .Net ServiceBus protocol will be unaffected.