### PR TITLE
Added check for the properties key

### DIFF
--- a/Ve.Messaging.Azure.ServiceBus/Infrastructure/BrokeredMessageBuilder.cs
+++ b/Ve.Messaging.Azure.ServiceBus/Infrastructure/BrokeredMessageBuilder.cs
@@ -27,7 +27,8 @@ namespace Ve.Messaging.Azure.ServiceBus.Infrastructure
             {
                 foreach (var item in message.Properties)
                 {
-                    brokeredMessage.Properties.Add(item.Key, item.Value);
+                    if (!brokeredMessage.Properties.ContainsKey(item.Key))
+                        brokeredMessage.Properties.Add(item.Key, item.Value);
                 }
             }
         }


### PR DESCRIPTION
To avoid any kind of exception during the creation of the brokered
message, it's needed to validate if the property list doesn't contain
the key received in the Message obj.
If there is a conflict the property from the message is discarted as the
brokeredmessage might have properties for internal control